### PR TITLE
[Dom] Render html in select options

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -5,6 +5,9 @@ This changelog references the relevant changes (bug and security fixes) done in 
 
 To get the diff for a specific change, go to https://github.com/PandaPlatform/ui/commit/XXX where XXX is the change hash
 
+* 3.2.5
+  * [Dom] Fix: Use innerHTML to display select option titles with html
+
 * 3.2.4
   * [Html] Create AbstractRender to simplify code and eliminate duplicates
   * [Html] Remove selected options from select elements when setting new values

--- a/Dom/DOMItem.php
+++ b/Dom/DOMItem.php
@@ -13,7 +13,6 @@ namespace Panda\Ui\Dom;
 
 use DOMElement;
 use DOMException;
-use DOMText;
 use Exception;
 use InvalidArgumentException;
 use Panda\Ui\Dom\Handlers\DOMHandlerInterface;
@@ -54,14 +53,9 @@ class DOMItem extends DOMElement
 
         // Check if the content a DOMNode to append
         if (gettype($value) == 'string') {
-            $valueNode = new DOMText($value);
+            $this->innerHTML($value);
         } else if (gettype($value) == 'object' && $value instanceof self) {
-            $valueNode = $value;
-        }
-
-        // Append value node
-        if (!empty($valueNode)) {
-            $this->append($valueNode);
+            $this->append($value);
         }
 
         // Add attributes, if any


### PR DESCRIPTION
Select options with string titles containing html was handled as plain text resulting in printing not only the actual text but also the html tags. This is avoided by using innerHTML function.

It is best to take into consideration Cross-Site Scripting attacks, if select options titles include html.