### PR TITLE
[Dom] Fix: Remove any html tags from select option title

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -5,6 +5,9 @@ This changelog references the relevant changes (bug and security fixes) done in 
 
 To get the diff for a specific change, go to https://github.com/PandaPlatform/ui/commit/XXX where XXX is the change hash
 
+* 3.2.7
+  * [Dom] Fix: Remove any html from select options titles to prevent html tag display
+
 * 3.2.6
   * [Dom] Revert use of innerHTML as it causes security issues with JavaScript injection
   

--- a/Dom/DOMItem.php
+++ b/Dom/DOMItem.php
@@ -54,7 +54,7 @@ class DOMItem extends DOMElement
 
         // Check if the content a DOMNode to append
         if (gettype($value) == 'string') {
-            $valueNode = new DOMText($value);
+            $valueNode = new DOMText(strip_tags($value));
         } else if (gettype($value) == 'object' && $value instanceof self) {
             $valueNode = $value;
         }


### PR DESCRIPTION
The tag option does not support child tags but will execute any injected script. In order to prevent displaying html tags inside the option titles or executing injected scripts we use strip_tags() to remove any tag found in the option title.